### PR TITLE
Update to 0.12.0-dev.2811+3cafb9655

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Straightforward HTTP-like request routing.
 
 ---
 
-Project is tested against zig 0.12.0-dev.2341+92211135f
+Project is tested against zig 0.12.0-dev.2811+3cafb9655
 
 ## Sample
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
     },
     .dependencies = .{
         .getty = .{
-            .url = "https://github.com/getty-zig/getty/archive/34e189c356f278981f84ec10d6d77c4a188d3cec.tar.gz",
-            .hash = "1220ce458470e5982a1d1b15a1571b17079c7f635639753d42f5c22d8903914784df",
+            .url = "https://github.com/getty-zig/getty/archive/165caba754c7424431b8ea233a315486f133acab.tar.gz",
+            .hash = "1220345b9da2d359d3be77486428eca92c824de275571c17d24e8a6bf8760593ecf0",
         },
     },
 }


### PR DESCRIPTION
Bumps the `getty` dependency version to fix [this error](https://github.com/getty-zig/getty/pull/154) seen on the latest Zig `0.12.0-dev.2811+3cafb9655`.

Tests still pass on this Zig version, so the tested Zig version in the readme was updated as well.