### PR TITLE
Update to Zig 0.13.0-dev.249+ed75f6256

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,14 +9,14 @@ pub fn build(b: *std.Build) void {
     const getty = b.dependency("getty", .{ .target = target, .optimize = optimize });
 
     const mod = b.addModule(package_name, .{
-        .root_source_file = .{ .path = package_path },
+        .root_source_file = b.path(package_path),
         .imports = &.{
             .{ .name = "getty", .module = getty.module("getty") },
         },
     });
 
     const exe_test = b.addTest(.{
-        .root_source_file = .{ .path = package_path },
+        .root_source_file = b.path(package_path),
         .target = target,
         .optimize = optimize,
     });
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
 
     const exe_example = b.addExecutable(.{
         .name = "example",
-        .root_source_file = .{ .path = "example/main.zig" },
+        .root_source_file = b.path("example/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -40,7 +40,7 @@ pub fn build(b: *std.Build) void {
 
     const doc_obj = b.addObject(.{
         .name = "docs",
-        .root_source_file = .{ .path = package_path },
+        .root_source_file = b.path(package_path),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
     },
     .dependencies = .{
         .getty = .{
-            .url = "https://github.com/getty-zig/getty/archive/805c4be6eacb988c968911a1cdfd585a8f54ae00.tar.gz",
-            .hash = "1220a5465b323d39df3cdfdc2a77d086d5079d142de48044da1b1feac87531fd6f1c",
+            .url = "https://github.com/getty-zig/getty/archive/78738b665a53db4be85696635b9c832fbca8d273.tar.gz",
+            .hash = "12204235c113ed912d951e381066d587bb398b7175dc635c50c17864946bbd570879",
         },
     },
 }


### PR DESCRIPTION
Updates build.zig due to changes in LazyPath.

Note: Before merging this PR, we need to update build.zig.zon after (https://github.com/getty-zig/getty/pull/157) is merged.